### PR TITLE
Update cake task to use flatland/useful, since cake removed its cake.util

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -4,7 +4,8 @@
   :resources-path "src/main/resources"
   :test-path "src/test/clojure"
   ;; :aot [swank-clj.main]
-  :dependencies [[org.clojure/clojure "1.2.1"]]
+  :dependencies [[org.clojure/clojure "1.2.1"]
+                 [useful "0.4.0"]]
   :dev-dependencies [[swank-clojure "1.2.1"]
                      [lein-swank-clj "1.0.0-SNAPSHOT"]
                      [org.clojure/clojure "1.2.1" :classifier "sources"]

--- a/src/main/clojure/cake/tasks/swank_clj.clj
+++ b/src/main/clojure/cake/tasks/swank_clj.clj
@@ -1,7 +1,7 @@
 (ns cake.tasks.swank-clj
   "A cake task for running swank-clj. Modified from cake.tasks.swank."
   (:use cake cake.core
-        [cake.utils.useful :only [if-ns]]
+        [useful.utils :only [if-ns]]
         [bake.core :only [current-context]]))
 
 (def current-port (atom nil))


### PR DESCRIPTION
Update cake task to use flatland/useful, since cake removed its cake.utils namespace.
