### PR TITLE
Fix markdown formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,12 +65,13 @@ using [Leiningen](http://github.com/technomancy/leiningen):
   [git](http://github.com/technomancy/clojure-mode).
 * lein plugin install lein-ritz "0.3.0-SNAPSHOT"
 * in your .emacs file, add the following and evalulate it (or restart emacs)
-```lisp
-(setq clojure-swank-command
-  (if (or (locate-file "lein" exec-path) (locate-file "lein.bat" exec-path))
-    "lein ritz-in %s"
-    "echo \"lein ritz-in %s\" | $SHELL -l"))
-```
+
+    ```lisp
+    (setq clojure-swank-command
+      (if (or (locate-file "lein" exec-path) (locate-file "lein.bat" exec-path))
+        "lein ritz-in %s"
+        "echo \"lein ritz-in %s\" | $SHELL -l"))
+    ```
 * From an Emacs buffer inside a project, invoke `M-x clojure-jack-in`
 
 ## Maven Plugin


### PR DESCRIPTION
The README had some code scrunched up on one really long line, but the intent was obviously to make it multiline; I fixed it to use markdown's (frankly bizarre) syntax to get multiline code snippets in a bulleted list.
