### PR TITLE
add lein-profile when started with "--no-debug"

### DIFF
--- a/lein-ritz/src/leiningen/ritz.clj
+++ b/lein-ritz/src/leiningen/ritz.clj
@@ -99,7 +99,7 @@
                             (dissoc :test-paths :source-paths :resource-paths)
                             (assoc :jvm-opts ["-Djava.awt.headless=true"
                                               "-XX:+TieredCompilation"]))
-                           project)]
+                           (project/merge-profiles project [ritz-profile]))]
        (eval-in-project
         start-project
         (ritz-form project (or port 0) (or host "localhost") opts)))))


### PR DESCRIPTION
The dependency is required to start the swank server.

```
 juergen@bitzer:~/clojure/p → lein ritz --no-debug 4005
 Exception in thread "main" java.lang.RuntimeException: java.io.FileNotFoundException: Could not locate    ritz/swank/socket_server__init.class or ritz/swank/socket_server.clj on classpath: 
```
