### PR TITLE
Use dynapath for reading the effective classpath from the class loader.

### DIFF
--- a/debugger/src/ritz/jpda/jdi_vm.clj
+++ b/debugger/src/ritz/jpda/jdi_vm.clj
@@ -5,6 +5,7 @@
   (:require
    [ritz.jpda.jdi :as jdi]
    [ritz.logging :as logging]
+   [ritz.repl-utils.class-browse :as class-browse]
    [clojure.pprint :as pprint]
    [clojure.string :as string])
   (:import
@@ -185,4 +186,4 @@ executes the provided `cmd`."
    ":"
    (map
     format-classpath-url
-    (.getURLs ^java.net.URLClassLoader (.getClassLoader clojure.lang.RT)))))
+    (class-browse/classpath-urls))))

--- a/repl-utils/project.clj
+++ b/repl-utils/project.clj
@@ -4,4 +4,5 @@
   :scm {:url "git@github.com:pallet/ritz.git"}
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[org.clojure/clojure "1.2.1"]])
+  :dependencies [[org.clojure/clojure "1.2.1"]
+                 [dynapath "0.1.0"]])

--- a/repl-utils/src/ritz/repl_utils/class_browse.clj
+++ b/repl-utils/src/ritz/repl_utils/class_browse.clj
@@ -23,7 +23,8 @@
   (:import [java.io File FilenameFilter]
            [java.util StringTokenizer]
            [java.util.jar JarFile JarEntry]
-           [java.util.regex Pattern]))
+           [java.util.regex Pattern])
+  (:require [dynapath.core :as dp]))
 
 ;;; Class file naming, categorization
 
@@ -119,7 +120,9 @@
 (defn classpath-urls
   "Return the classpath URL's for the current clojure classloader."
   []
-  (.getURLs ^java.net.URLClassLoader (.getClassLoader clojure.lang.RT)))
+  (let [cl (.getClassLoader clojure.lang.RT)]
+    (when (dp/readable-classpath? cl)
+      (dp/classpath-urls cl))))
 
 (defn classpath
   "Return the classpath File's for the current clojure classloader."


### PR DESCRIPTION
As we discussed on #leiningen, I've created a project that provides an abstraction for readiing/modifying class loaders (https://github.com/tobias/dynapath). This commit modifies ritz to use it in places where it needs to read the effective classpath.

This allows class-browse/classpath-urls and jdi-vm/current-classpath to work with non-URLClassLoaders. It doesn't deal with adding event exclusions for non-URLClassLoaders. If that becomes an issue, I'll look at addressing that in a different commit.
