### PR TITLE
Fix #52

### DIFF
--- a/debugger/src/ritz/jpda/jdi.clj
+++ b/debugger/src/ritz/jpda/jdi.clj
@@ -11,6 +11,8 @@
   (:use
    [clojure.stacktrace :only [print-cause-trace]])
   (:import
+   (java.io
+    File)
    (com.sun.jdi
     VirtualMachine PathSearchingVirtualMachine
     Bootstrap VMDisconnectedException
@@ -72,7 +74,10 @@
            quote-args (.get arguments "quote")
            main-args (.get arguments "main")
            option-args (.get arguments "options")
-           args (str " -cp '" classpath "' clojure.main -e '" expr "'")]
+           init-file (File/createTempFile "ritz-init" ".clj")
+           args (str " -cp '" classpath "' clojure.main -i " (.getCanonicalPath init-file))]
+       (.deleteOnExit init-file)
+       (spit init-file expr)
        (logging/trace "jdi/launch %s" args)
        (logging/trace "jdi/launch options %s" (string/join " " options))
        (.setValue quote-args "'")

--- a/nrepl/src/ritz/nrepl.clj
+++ b/nrepl/src/ritz/nrepl.clj
@@ -255,7 +255,7 @@ generate a name for the thread."
                 :bind "localhost" :port 0 :ack-port ack-port
                 :handler (debug-handler host port))
         vm (launch-vm (merge
-                       {:classpath (join ":" vm-classpath) :main `@(promise)}
+                       {:classpath (join java.io.File/pathSeparatorChar vm-classpath) :main `@(promise)}
                        (select-keys options [:jvm-opts])))
         msg-thread (start-remote-thread vm "msg-pump")
         vm (assoc vm :msg-pump-thread msg-thread)


### PR DESCRIPTION
I reworked the launching of the debuggee (use init-file instead of a init-form)

This should fix https://github.com/pallet/ritz/issues/52 which also happens when using the swank backend.  The cause on Windows systems is this  Exception:

```
 ["detailMessage" #<StringReferenceImpl "java.lang.RuntimeException: Unable to resolve symbol: JDI-VM-Control-Thread in this context, compiling:(NO_SOURCE_PATH:1)">]
```
