### PR TITLE
Ensure encoding related JVM options are passed to the controlling debugg...

### DIFF
--- a/lein-ritz/src/leiningen/ritz.clj
+++ b/lein-ritz/src/leiningen/ritz.clj
@@ -102,6 +102,7 @@
               (assoc :server-ns
                 (if debug 'ritz.swank.proxy 'ritz.swank.repl))
               (update-in [:log-level] #(when % (keyword %))))
+        jvm-eopts (filter #(re-matches #"^-D(swank|file).encoding.*" %) (:jvm-opts project))
         start-project (if debug
                         (->
                          project
@@ -109,7 +110,7 @@
                          (project/merge-profiles
                           [clojure-profile lein-profile ritz-profile])
                          (dissoc :test-paths :source-paths :resource-paths)
-                         (assoc :jvm-opts ["-Djava.awt.headless=true"
-                                           "-XX:+TieredCompilation"]))
+                         (assoc :jvm-opts (concat ["-Djava.awt.headless=true" "-XX:+TieredCompilation"]
+                                                  jvm-eopts)))
                         (project/merge-profiles project [ritz-profile]))]
     (eval-in-project start-project (ritz-form project port host opts))))


### PR DESCRIPTION
...er vm, refs #62

The swank connection reader should use the encoding specified in the
projects JVM options (-Dswank.encoding=...)
