### PR TITLE
Update to latest dynapath to resolve transitive dep issues.

### DIFF
--- a/repl-utils/project.clj
+++ b/repl-utils/project.clj
@@ -5,4 +5,4 @@
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.2.1"]
-                 [dynapath "0.1.0"]])
+                 [org.tcrawley/dynapath "0.2.1"]])

--- a/repl-utils/src/ritz/repl_utils/class_browse.clj
+++ b/repl-utils/src/ritz/repl_utils/class_browse.clj
@@ -24,7 +24,7 @@
            [java.util StringTokenizer]
            [java.util.jar JarFile JarEntry]
            [java.util.regex Pattern])
-  (:require [dynapath.core :as dp]))
+  (:require [dynapath.util :as dp]))
 
 ;;; Class file naming, categorization
 
@@ -120,9 +120,7 @@
 (defn classpath-urls
   "Return the classpath URL's for the current clojure classloader."
   []
-  (let [cl (.getClassLoader clojure.lang.RT)]
-    (when (dp/readable-classpath? cl)
-      (dp/classpath-urls cl))))
+  (dp/classpath-urls (.getClassLoader clojure.lang.RT)))
 
 (defn classpath
   "Return the classpath File's for the current clojure classloader."


### PR DESCRIPTION
Dynapath renamed core -> util for 0.2.0, released to central for
0.2.1 (requiring a group), and dynapath.util/classpath-urls now
contains a check to verify the given CL is readable, so I removed that
check.
