### PR TITLE
Update to newer dynapath.

### DIFF
--- a/repl-utils/project.clj
+++ b/repl-utils/project.clj
@@ -5,4 +5,4 @@
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.2.1"]
-                 [org.tcrawley/dynapath "0.2.1"]])
+                 [org.tcrawley/dynapath "0.2.3"]])


### PR DESCRIPTION
0.2.1 had an issue that allowed pomegranate to modify the boot
classloader, which caused strange errors.
