### PR TITLE
Fixes for line breakpoints

### DIFF
--- a/debugger/src/ritz/jpda/jdi.clj
+++ b/debugger/src/ritz/jpda/jdi.clj
@@ -431,7 +431,7 @@
   "Return a regular expression pattern for matching all classes in the
    given namespace name"
   [ns]
-  (re-pattern (str (string/replace ns "-" "_") "\\$")))
+  (re-pattern (string/replace ns "-" "_")))
 
 (defn namespace-classes
   "Return all classes for the given namespace"

--- a/swank/elisp/slime-ritz.el
+++ b/swank/elisp/slime-ritz.el
@@ -30,13 +30,13 @@ With prefix argument FLAG, do not break on exception"
   (interactive)
   (slime-eval-with-transcript
    `(swank:line-breakpoint
-     ,(slime-current-package) ,(buffer-name) ,(line-number-at-pos))))
+     ,(slime-current-package) ,(buffer-file-name) ,(line-number-at-pos))))
 
 (defun slime-java-line-breakpoint ()
   "Set a breakpoint at the current line in java"
   (interactive)
   (slime-eval-with-transcript
-   `(swank:line-breakpoint nil ,(buffer-name) ,(line-number-at-pos))))
+   `(swank:line-breakpoint nil ,(buffer-file-name) ,(line-number-at-pos))))
 
 ;;;; Breakpoints
 (defvar slime-breakpoints-buffer-name (slime-buffer-name :breakpoints))


### PR DESCRIPTION
Hi Hugo,

I can't set Breakpoints on Java source lines because the regular expression limts valid class names to inner classes.

Also invalid file names are used because I have my buffer-name-style  based on "reverse" file names.

best regards

Jürgen
