### PR TITLE
Rebind `q` in debug buffer

### DIFF
--- a/nrepl/elisp/nrepl-ritz.el
+++ b/nrepl/elisp/nrepl-ritz.el
@@ -845,7 +845,7 @@ Full list of commands:
   ("x"    'nrepl-dbg-step-over)
   ("o"    'nrepl-dbg-step-out)
   ("a"    'nrepl-dbg-abort)
-  ("q"    'nrepl-dbg-quit)
+  ("q"    'nrepl-dbg-abort)
   ("P"    'nrepl-dbg-print-exception)
   ("C"    'nrepl-dbg-inspect-exception)
   (":"    'nrepl-interactive-eval))


### PR DESCRIPTION
As it's set now, `q` just breaks the entire nrepl/ritz session. I bound it to `abort` instead of `quit`, and now it does roughly what's expected by slime/swank users.
