### PR TITLE
Added eval before the variable expansion

### DIFF
--- a/nrepl/elisp/nrepl-ritz.el
+++ b/nrepl/elisp/nrepl-ritz.el
@@ -19,7 +19,7 @@
   (if (or (locate-file nrepl-lein-command exec-path)
           (locate-file (format "%s.bat" nrepl-lein-command) exec-path))
       (format "%s ritz-nrepl" nrepl-lein-command)
-    (format "echo \"%s ritz-nrepl\" | $SHELL -l" nrepl-lein-command))
+    (format "echo \"%s ritz-nrepl\" | eval $SHELL -l" nrepl-lein-command))
   "The command used to start the nREPL via `nrepl-ritz-jack-in'.
 For a remote nREPL server lein must be in your PATH.  The remote
 proc is launched via sh rather than bash, so it might be necessary


### PR DESCRIPTION
fish shell doesn't support to use variable as commands
(on purpose, see: http://lwn.net/Articles/136232/ "Impossible to Validate the Syntax" )

this is an almost identical PR: https://github.com/kingtim/nrepl.el/pull/192
