### PR TITLE
debugger uses filterv which is from clojure 1.4

### DIFF
--- a/debugger/project.clj
+++ b/debugger/project.clj
@@ -4,7 +4,8 @@
   :scm {:url "git@github.com:pallet/ritz.git"}
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[ritz/ritz-repl-utils "0.7.1-SNAPSHOT"]]
+  :dependencies [[org.clojure/clojure "1.4.0"]
+                 [ritz/ritz-repl-utils "0.7.1-SNAPSHOT"]]
   :profiles {:dev {:dependencies [[classlojure "0.6.6"]
                                   [bultitude "0.1.7"]]
                    :plugins [[lein-jdk-tools "0.1.0"]]}})

--- a/repl-utils/project.clj
+++ b/repl-utils/project.clj
@@ -4,5 +4,5 @@
   :scm {:url "git@github.com:pallet/ritz.git"}
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[org.clojure/clojure "1.4.0"]
+  :dependencies [[org.clojure/clojure "1.2.1"]
                  [org.tcrawley/dynapath "0.2.3"]])

--- a/repl-utils/project.clj
+++ b/repl-utils/project.clj
@@ -4,5 +4,5 @@
   :scm {:url "git@github.com:pallet/ritz.git"}
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[org.clojure/clojure "1.2.1"]
+  :dependencies [[org.clojure/clojure "1.4.0"]
                  [org.tcrawley/dynapath "0.2.3"]])


### PR DESCRIPTION
Since it was being used by repl-utils it failed after running the first round of tests.
